### PR TITLE
Update Crate dependecies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bincode = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 rand = "0.8"
 hex = "0.4"
-sha2 = "0.9"
+sha2 = "0.10.8"
 
 [[example]]
 name = "simple_run"


### PR DESCRIPTION
Partially Closes #5

Referred https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html to upgrade to latest rust. It seems _Rust 2024 edition is not yet released_ [ref](https://doc.rust-lang.org/edition-guide/rust-2024/index.html).

## Testing
Made use of [cargo-outdated](https://crates.io/crates/cargo-outdated) crate to check for outdated dependecies and updated them. Reused the same to verify
```
  ~/code/raft-rs   lib-maintenance !1 ?1 ❯ cargo outdated                                                                                                                                    17:02:10
All dependencies are up to date, yay!
  ~/code/raft-rs   lib-maintenance !1 ?1 ❯    
```