### PR TITLE
Add test cases for `server.rs`

### DIFF
--- a/examples/simple_run.rs
+++ b/examples/simple_run.rs
@@ -47,7 +47,7 @@ async fn main() {
         let cc = cluster_config.clone();
         handles.push(tokio::spawn(async move {
             let mut server = Server::new(id, config, cc).await;
-            server.start().await;
+            server.start(None).await;
         }));
     }
 

--- a/examples/simulate_add_node.rs
+++ b/examples/simulate_add_node.rs
@@ -44,7 +44,7 @@ async fn main() {
         let cc = cluster_config.clone();
         handles.push(tokio::spawn(async move {
             let mut server = Server::new(id, config, cc).await;
-            server.start().await;
+            server.start(None).await;
         }));
     }
 
@@ -65,7 +65,7 @@ async fn main() {
     // Launching a new node
     handles.push(tokio::spawn(async move {
         let mut server = Server::new(new_node_id, new_node_conf, cluster_config).await;
-        server.start().await;
+        server.start(None).await;
     }));
 
     // Simulate sending a Raft Join request after a few seconds

--- a/examples/simulate_node_failure.rs
+++ b/examples/simulate_node_failure.rs
@@ -46,7 +46,7 @@ async fn main() {
         let cc = cluster_config.clone();
         let server_handle = tokio::spawn(async move {
             let mut server = Server::new(id, config, cc).await;
-            server.start().await;
+            server.start(None).await;
         });
         server_handles.push(server_handle);
     }
@@ -78,7 +78,7 @@ async fn main() {
         let cc = cluster_config.clone();
         let server_handle = tokio::spawn(async move {
             let mut server = Server::new(server_to_stop.try_into().unwrap(), config, cc).await;
-            server.start().await;
+            server.start(None).await;
         });
         server_handles[server_to_stop - 1] = server_handle;
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -39,7 +39,7 @@ enum MessageType {
     JoinResponse,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct ServerState {
     current_term: u32,
     state: RaftState,
@@ -70,7 +70,7 @@ pub struct LogEntry {
     pub data: u32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ServerConfig {
     pub election_timeout: Duration,
     pub address: SocketAddr,
@@ -80,6 +80,7 @@ pub struct ServerConfig {
     pub storage_location: Option<String>,
 }
 
+#[derive(Clone)]
 pub struct Server {
     pub id: u32,
     state: ServerState,


### PR DESCRIPTION
Closes: #21 

**Changes proposed in the MR**:
- Adding `mpsc::channel` in `server.start` method to stop based on the communication as this is required for writing test case else `loop` will continue forever.
- Update examples directory code snippets.
- Adding test cases for the below methods.
- [x] `pub async fn new(id: u32, config: ServerConfig, cluster_config: ClusterConfig) -> Server {`
- [x] `pub async fn start(&mut self, rx: Option<mpsc::Receiver<()>>) {`
- [ ]  `pub fn is_leader(&self) -> bool {`
- [ ] `async fn follower(&mut self) {`
- [ ] `async fn candidate(&mut self) {`
- [ ] `async fn leader(&mut self) {`
- [ ] `async fn receive_rpc(&mut self) {`
- [ ] `async fn handle_rpc(&mut self, data: Vec<u8>) {`
- [ ] `async fn handle_client_request(&mut self, data: Vec<u8>) {`
- [ ] `async fn handle_request_vote(&mut self, data: &[u8]) {`
- [ ] `async fn handle_request_vote_response(&mut self, data: &[u8]) {`
- [ ] `async fn handle_append_entries(&mut self, data: Vec<u8>) {`
- [ ] `async fn handle_append_entries_response(&mut self, data: &[u8]) {`
- [ ] `async fn handle_heartbeat(&mut self, data: &[u8]) {`
- [ ] `async fn handle_heartbeat_response(&mut self) {`
- [ ] `async fn handle_repair_request(&mut self, data: &[u8]) {`
- [ ] `async fn handle_repair_response(&mut self, data: &[u8]) {`
- [ ] `async fn handle_join_request(&mut self, data: &[u8]) {`
- [ ] `async fn handle_join_response(&mut self, data: &[u8]) {`
- [ ] `async fn persist_to_disk(&mut self, id: u32, data: &[u8]) {`
- [ ] `async fn stop(self) {`
