### PR TITLE
add file snapshot

### DIFF
--- a/examples/simple_run.rs
+++ b/examples/simple_run.rs
@@ -46,7 +46,7 @@ async fn main() {
         let id = cluster_nodes[i];
         let cc = cluster_config.clone();
         handles.push(tokio::spawn(async move {
-            let mut server = Server::new(id, config, cc).await;
+            let mut server = Server::new(id, config, cc, None).await;
             server.start().await;
         }));
     }

--- a/examples/simulate_add_node.rs
+++ b/examples/simulate_add_node.rs
@@ -43,7 +43,7 @@ async fn main() {
         let id = cluster_nodes[i];
         let cc = cluster_config.clone();
         handles.push(tokio::spawn(async move {
-            let mut server = Server::new(id, config, cc).await;
+            let mut server = Server::new(id, config, cc, None).await;
             server.start().await;
         }));
     }
@@ -64,7 +64,7 @@ async fn main() {
 
     // Launching a new node
     handles.push(tokio::spawn(async move {
-        let mut server = Server::new(new_node_id, new_node_conf, cluster_config).await;
+        let mut server = Server::new(new_node_id, new_node_conf, cluster_config, None).await;
         server.start().await;
     }));
 

--- a/examples/simulate_node_failure.rs
+++ b/examples/simulate_node_failure.rs
@@ -45,7 +45,7 @@ async fn main() {
         let id = cluster_nodes[i];
         let cc = cluster_config.clone();
         let server_handle = tokio::spawn(async move {
-            let mut server = Server::new(id, config, cc).await;
+            let mut server = Server::new(id, config, cc, None).await;
             server.start().await;
         });
         server_handles.push(server_handle);
@@ -77,7 +77,8 @@ async fn main() {
         };
         let cc = cluster_config.clone();
         let server_handle = tokio::spawn(async move {
-            let mut server = Server::new(server_to_stop.try_into().unwrap(), config, cc).await;
+            let mut server =
+                Server::new(server_to_stop.try_into().unwrap(), config, cc, None).await;
             server.start().await;
         });
         server_handles[server_to_stop - 1] = server_handle;

--- a/examples/simulate_replica_repair.rs
+++ b/examples/simulate_replica_repair.rs
@@ -57,7 +57,7 @@ async fn main() {
                 warn!(get_logger(), "Storage for server {} is corrupted", id);
             }
 
-            let mut server = Server::new(id, config, cc).await;
+            let mut server = Server::new(id, config, cc, None).await;
             server.start().await;
         });
         server_handles.push(server_handle);
@@ -98,7 +98,8 @@ async fn main() {
                 leadership_preferences: HashMap::new(),
                 storage_location: Some(storage_path.clone()),
             };
-            let mut server = Server::new(server_to_fail.try_into().unwrap(), config, cc).await;
+            let mut server =
+                Server::new(server_to_fail.try_into().unwrap(), config, cc, None).await;
             server.start().await;
             // Handle recovery of corrupted storage
             info!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,9 @@ pub enum Error {
     /// Some other error occurred.
     #[error("unknown error {0}")]
     Unknown(#[from] Box<dyn std::error::Error + Sync + Send>),
+    /// To handle all bincode error
+    #[error("Bincode error {0}")]
+    BincodeError(#[from] bincode::Error),
 }
 
 #[derive(Error, Debug)]
@@ -39,6 +42,8 @@ pub enum NetworkError {
 
 #[derive(Error, Debug)]
 pub enum StorageError {
+    #[error("Path not found")]
+    PathNotFound,
     #[error("File is empty")]
     EmptyFile,
     #[error("File is corrupted")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@ pub mod error;
 pub mod log;
 pub mod network;
 pub mod server;
+pub mod state_mechine;
 pub mod storage;

--- a/src/network.rs
+++ b/src/network.rs
@@ -77,7 +77,7 @@ impl NetworkLayer for TCPManager {
         join_all(futures)
             .await
             .into_iter()
-            .collect::<std::result::Result<_, _>>()
+            .collect::<Result<Vec<()>>>()
             // FIXME: We should let client decide what to do with the errors
             .map_err(|e| NetworkError::BroadcastError(e.to_string()))?;
         Ok(())

--- a/src/state_mechine.rs
+++ b/src/state_mechine.rs
@@ -1,0 +1,344 @@
+use std::path::PathBuf;
+use std::time::Duration;
+use std::{fmt::Debug, path::Path};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+use tokio::io::AsyncReadExt;
+use tokio::{fs::OpenOptions, io::AsyncWriteExt, time::Instant};
+
+use crate::error::StorageError::PathNotFound;
+use crate::{error::Error, error::Result, server::LogEntry};
+
+#[async_trait]
+pub trait StateMachine: Debug + Send + Sync {
+    // Retrieve the current term stored in the state machine
+    async fn get_term(&self) -> u32;
+
+    // Retrieve the current log index stored in the state machine
+    async fn get_index(&self) -> u32;
+
+    // Apply a single log entry to the state machine, updating term, index, and log entries
+    async fn apply_log_entry(
+        &mut self,
+        last_included_term: u32,
+        last_included_index: u32,
+        log_entry: LogEntry,
+    );
+
+    // Apply multiple log entries to the state machine in bulk
+    async fn apply_log_entrys(
+        &mut self,
+        last_included_term: u32,
+        last_included_index: u32,
+        mut log_entrys: Vec<LogEntry>,
+    );
+
+    // Retrieve all log entries currently stored in the state machine
+    async fn get_log_entry(&mut self) -> Result<Vec<LogEntry>>;
+
+    // Create a snapshot of the current state to the file system, and clear the log data after
+    async fn create_snapshot(&mut self) -> Result<()>;
+
+    // Check if a snapshot is required based on the interval since the last snapshot
+    async fn need_create_snapshot(&mut self) -> bool;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FileStateMachine {
+    last_included_term: u32,
+    last_included_index: u32,
+    data: Vec<LogEntry>,
+
+    #[serde(skip)]
+    snapshot_path: Option<Box<Path>>,
+
+    /// The time interval between snapshots.
+    #[serde(skip)]
+    snapshot_interval: Duration,
+
+    /// The time when snapshot generation started
+    #[serde(skip)]
+    snapshot_start_time: Option<Instant>,
+
+    /// Whether the state machine is currently generating a snapshot
+    #[serde(skip)]
+    is_snapshotting: bool,
+
+    /// The time when the last snapshot was completed
+    #[serde(skip)]
+    last_snapshot_complete_time: Option<Instant>,
+}
+
+impl FileStateMachine {
+    /// Create a new FileStateMachine with initial values
+    pub fn new(snapshot_path: &Path, snapshot_interval: Duration) -> Self {
+        let current_time = Instant::now();
+        Self {
+            snapshot_path: Some(PathBuf::from(snapshot_path).into_boxed_path()),
+            last_included_term: 0,
+            last_included_index: 0,
+            data: Vec::new(),
+            snapshot_interval,
+            snapshot_start_time: Some(current_time),
+            is_snapshotting: false,
+            last_snapshot_complete_time: Some(current_time),
+        }
+    }
+}
+
+/// Implement the StateMachine trait for FileStateMachine
+/// Generate snapshots based on time intervals as I record start, end time
+/// The data in memory is cleared after generating a snapshot, to save memory
+#[async_trait]
+impl StateMachine for FileStateMachine {
+    async fn get_term(&self) -> u32 {
+        self.last_included_term
+    }
+
+    async fn get_index(&self) -> u32 {
+        self.last_included_index
+    }
+
+    async fn apply_log_entry(
+        &mut self,
+        last_included_term: u32,
+        last_included_index: u32,
+        log_entry: LogEntry,
+    ) {
+        self.last_included_term = last_included_term;
+        self.last_included_index = last_included_index;
+        self.data.push(log_entry);
+    }
+
+    async fn apply_log_entrys(
+        &mut self,
+        last_included_term: u32,
+        last_included_index: u32,
+        mut log_entrys: Vec<LogEntry>,
+    ) {
+        self.last_included_term = last_included_term;
+        self.last_included_index = last_included_index;
+        self.data.append(&mut log_entrys);
+    }
+
+    async fn create_snapshot(&mut self) -> Result<()> {
+        let snapshot_path = if let Some(ref path) = self.snapshot_path {
+            path
+        } else {
+            return Err(Error::Store(PathNotFound));
+        };
+
+        self.snapshot_start_time = Some(Instant::now());
+        self.is_snapshotting = true;
+
+        // Step 1: Read the existing snapshot from file if it exists
+        let mut existing_fsm = FileStateMachine::new(snapshot_path, Duration::from_secs(0));
+        if fs::metadata(snapshot_path).await.is_ok() {
+            let mut file = OpenOptions::new().read(true).open(snapshot_path).await?;
+            let mut buffer = Vec::new();
+            file.read_to_end(&mut buffer).await.map_err(Error::Io)?;
+
+            if !buffer.is_empty() {
+                existing_fsm = bincode::deserialize(&buffer).map_err(Error::BincodeError)?;
+            }
+        }
+
+        // Step 2: Merge existing snapshot data
+        self.data.splice(0..0, existing_fsm.data.drain(..));
+
+        // Step 3: Write the merged state back to the snapshot file
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(snapshot_path)
+            .await?;
+        let bytes = bincode::serialize(&self).map_err(Error::BincodeError)?;
+        file.write_all(&bytes).await?;
+        file.sync_all().await.map_err(Error::Io)?;
+
+        // Step 4: Clear `data` after snapshot is created successfully
+        self.data.clear();
+
+        self.last_snapshot_complete_time = Some(Instant::now());
+        self.is_snapshotting = false;
+
+        Ok(())
+    }
+
+    /// Check if a new snapshot is needed.
+    async fn need_create_snapshot(&mut self) -> bool {
+        if self.is_snapshotting {
+            return false; // If we are currently snapshotting, we don't need another snapshot
+        }
+
+        if let Some(last_snapshot_time) = self.last_snapshot_complete_time {
+            // Calculate the time since the last snapshot was completed
+            let time_since_last_snapshot = Instant::now().duration_since(last_snapshot_time);
+
+            // If the time since the last snapshot is greater than the snapshot interval, return true
+            if time_since_last_snapshot >= self.snapshot_interval {
+                // self.last_snapshot_complete_time = Some(Instant::now());
+                return true;
+            }
+        } else {
+            // If we never completed a snapshot, we need to create one
+            return true;
+        }
+
+        false
+    }
+
+    async fn get_log_entry(&mut self) -> Result<Vec<LogEntry>> {
+        let snapshot_path = if let Some(ref path) = self.snapshot_path {
+            path
+        } else {
+            return Err(Error::Store(PathNotFound));
+        };
+
+        let mut existing_fsm = FileStateMachine::new(snapshot_path, Duration::from_secs(0));
+        if fs::metadata(snapshot_path).await.is_ok() {
+            let mut file = OpenOptions::new().read(true).open(snapshot_path).await?;
+            let mut buffer = Vec::new();
+            file.read_to_end(&mut buffer).await.map_err(Error::Io)?;
+
+            if !buffer.is_empty() {
+                existing_fsm = bincode::deserialize(&buffer).map_err(Error::BincodeError)?;
+            }
+        }
+
+        self.data.splice(0..0, existing_fsm.data.drain(..));
+
+        Ok(self.data.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::server::LogCommand;
+
+    use super::*;
+    use tempfile::NamedTempFile;
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn test_apply_log_entry() {
+        let tmp_file = NamedTempFile::new().unwrap();
+        let snapshot_path = tmp_file.path().to_str().unwrap();
+
+        let mut fsm = FileStateMachine {
+            snapshot_path: Option::Some(PathBuf::from(snapshot_path).into_boxed_path()),
+            last_included_term: 0,
+            last_included_index: 0,
+            data: vec![],
+            snapshot_interval: Duration::from_secs(300),
+            snapshot_start_time: None,
+            is_snapshotting: false,
+            last_snapshot_complete_time: None,
+        };
+
+        let log_entry = LogEntry {
+            term: 1,
+            command: LogCommand::Set,
+            leader_id: 1,
+            server_id: 1,
+            data: 1,
+        };
+
+        fsm.apply_log_entry(1, 1, log_entry.clone()).await;
+
+        let log_entries = fsm.get_log_entry().await.unwrap();
+        assert_eq!(log_entries.len(), 1);
+        assert_eq!(log_entries[0], log_entry);
+        assert_eq!(fsm.last_included_term, 1);
+        assert_eq!(fsm.last_included_index, 1);
+    }
+
+    #[tokio::test]
+    async fn test_need_create_snapshot() {
+        let mut fsm = FileStateMachine {
+            snapshot_path: None,
+            last_included_term: 0,
+            last_included_index: 0,
+            data: vec![],
+            snapshot_interval: Duration::from_secs(1),
+            snapshot_start_time: None,
+            is_snapshotting: false,
+            last_snapshot_complete_time: Some(Instant::now()),
+        };
+
+        // Immediately after completing snapshot, no snapshot should be needed
+        assert!(!fsm.need_create_snapshot().await);
+
+        // Wait for more than the interval and check again
+        sleep(Duration::from_secs(2)).await;
+        assert!(fsm.need_create_snapshot().await);
+    }
+
+    #[tokio::test]
+    async fn test_create_snapshot() {
+        let tmp_file = NamedTempFile::new().unwrap();
+        let snapshot_path = tmp_file.path().to_str().unwrap();
+
+        // Create a FileStateMachine with some data
+        let mut fsm = FileStateMachine {
+            snapshot_path: Some(PathBuf::from(snapshot_path).into_boxed_path()),
+            last_included_term: 1,
+            last_included_index: 1,
+            data: vec![
+                LogEntry {
+                    term: 1,
+                    command: LogCommand::Set,
+                    leader_id: 1,
+                    server_id: 1,
+                    data: 1,
+                },
+                LogEntry {
+                    term: 2,
+                    command: LogCommand::Set,
+                    leader_id: 2,
+                    server_id: 2,
+                    data: 2,
+                },
+            ],
+            snapshot_interval: Duration::from_secs(300),
+            snapshot_start_time: None,
+            is_snapshotting: false,
+            last_snapshot_complete_time: None,
+        };
+
+        // Call create_snapshot and check result
+        let result = fsm.create_snapshot().await;
+        assert!(result.is_ok(), "Snapshot creation failed");
+
+        // Check that the snapshot file is created
+        let metadata = std::fs::metadata(snapshot_path);
+        assert!(metadata.is_ok(), "Snapshot file was not created");
+
+        // Read the file back and deserialize it to check contents
+        let snapshot_data = std::fs::read(snapshot_path).unwrap();
+        let deserialized_fsm: FileStateMachine = bincode::deserialize(&snapshot_data).unwrap();
+
+        // Check that the deserialized data matches the original state machine
+        assert_eq!(deserialized_fsm.data.len(), 2);
+
+        // Check that the snapshot start and complete times were set
+        assert!(
+            fsm.snapshot_start_time.is_some(),
+            "Snapshot start time was not set"
+        );
+        assert!(
+            fsm.last_snapshot_complete_time.is_some(),
+            "Snapshot complete time was not set"
+        );
+
+        // Check that is_snapshotting was set to false after completion
+        assert!(
+            !fsm.is_snapshotting,
+            "is_snapshotting should be false after snapshot completion"
+        );
+    }
+}


### PR DESCRIPTION
The process was rushed with one write-up, sorry; please review it for me, thanks.

I decided to remove the original `log` field, my idea was to just make sure that the `state_machine` data is complete, which has the advantage of saving memory(storing both the `log` and the `state_machine` would be two copies of the data), I didn't think about whether there would be a problem at the moment.

I added timed snapshots, maybe 1 minute, 5 minutes, ....

After the snapshot is created, clear the data in memory, in order to save memory.

I haven't figured out where to put `need_create_snapshot` and `create_snapshot` yet, wait for me some time, it's rather rushed;


```shell
/cloudide/workspace/raft-rs$ cargo run --example simulate_add_node
   Compiling raft_rs v0.1.0 (/cloudide/workspace/raft-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 1.72s
     Running `target/debug/examples/simulate_add_node`
2024-09-06 05:45:04 INFO Log after reading from disk: Ok([LogEntry { leader_id: 1, server_id: 3, term: 2, command: Set, data: 42 }]), current term: 2, id: 3, port: 5003, ip: 127.0.0.1
2024-09-06 05:45:04 INFO Log after reading from disk: Ok([LogEntry { leader_id: 1, server_id: 4, term: 2, command: Set, data: 42 }]), current term: 2, id: 4, port: 5004, ip: 127.0.0.1
2024-09-06 05:45:04 INFO Server 3 is a follower, id: 3, port: 5003, ip: 127.0.0.1
2024-09-06 05:45:04 INFO Server 4 is a follower, id: 4, port: 5004, ip: 127.0.0.1
2024-09-06 05:45:04 INFO Log after reading from disk: Ok([LogEntry { leader_id: 1, server_id: 1, term: 2, command: Set, data: 42 }]), current term: 2, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:04 INFO Log after reading from disk: Ok([LogEntry { leader_id: 1, server_id: 5, term: 2, command: Set, data: 42 }]), current term: 2, id: 5, port: 5005, ip: 127.0.0.1
2024-09-06 05:45:04 INFO Server 1 is a follower, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:04 INFO Server 5 is a follower, id: 5, port: 5005, ip: 127.0.0.1
2024-09-06 05:45:04 INFO Log after reading from disk: Ok([LogEntry { leader_id: 1, server_id: 2, term: 2, command: Set, data: 42 }]), current term: 2, id: 2, port: 5002, ip: 127.0.0.1
2024-09-06 05:45:04 INFO Server 2 is a follower, id: 2, port: 5002, ip: 127.0.0.1
2024-09-06 05:45:05 INFO Server 1 is a candidate, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:05 INFO Starting election, id: 1, term: 3, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:05 INFO Votes received: {1: true, 2: true}, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:05 INFO Votes received: {4: true, 1: true, 2: true}, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:05 INFO Quorum reached, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:05 INFO I am the leader 1, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:05 INFO Server 1 is the leader, term: 4, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:14 INFO Log after reading from disk: Ok([]), current term: 0, id: 6, port: 5006, ip: 127.0.0.1
2024-09-06 05:45:14 INFO Server 6 is a follower, id: 6, port: 5006, ip: 127.0.0.1
2024-09-06 05:45:15 INFO Server 6 is a candidate, id: 6, port: 5006, ip: 127.0.0.1
2024-09-06 05:45:15 INFO Starting election, id: 6, term: 2, id: 6, port: 5006, ip: 127.0.0.1
2024-09-06 05:45:16 INFO Election timeout, id: 6, port: 5006, ip: 127.0.0.1
2024-09-06 05:45:16 INFO Log after reading from disk: Ok([]), current term: 2, id: 6, port: 5006, ip: 127.0.0.1
2024-09-06 05:45:16 INFO Server 6 is a follower, id: 6, port: 5006, ip: 127.0.0.1
2024-09-06 05:45:17 INFO Received join request: "\0\0\0\u{6}\0\0\0\0\0\0\0\n127.0.0.1:5006", id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:17 INFO Current cluster nodes: ["127.0.0.1:5001", "127.0.0.1:5002", "127.0.0.1:5003", "127.0.0.1:5004", "127.0.0.1:5005"], want join node: 127.0.0.1:5006, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:17 INFO Sending log entrys to new node: [LogEntry { leader_id: 1, server_id: 1, term: 2, command: Set, data: 42 }], id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:45:17 INFO Joined the cluster with leader: 1, own id: 6, id: 6, port: 5006, ip: 127.0.0.1
2024-09-06 05:45:17 INFO Received batch append entries response from peer: 6, current peer last_included_term: 2, id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:46:04 INFO Node: 5, snapshot created successfully., id: 5, port: 5005, ip: 127.0.0.1
2024-09-06 05:46:04 INFO Node: 4, snapshot created successfully., id: 4, port: 5004, ip: 127.0.0.1
2024-09-06 05:46:04 INFO Node: 3, snapshot created successfully., id: 3, port: 5003, ip: 127.0.0.1
2024-09-06 05:46:04 INFO Node: 1, snapshot created successfully., id: 1, port: 5001, ip: 127.0.0.1
2024-09-06 05:46:04 INFO Node: 2, snapshot created successfully., id: 2, port: 5002, ip: 127.0.0.1
2024-09-06 05:46:14 INFO Node: 6, snapshot created successfully., id: 6, port: 5006, ip: 127.0.0.1
^C
```